### PR TITLE
fix: Add cutting boards block tag

### DIFF
--- a/kubejs/data/sandwichable/tags/blocks/cutting_boards.json
+++ b/kubejs/data/sandwichable/tags/blocks/cutting_boards.json
@@ -1,0 +1,13 @@
+{
+  "replace": false,
+  "values": [
+    "sandwichable:oak_cutting_board",
+    "sandwichable:spruce_cutting_board",
+    "sandwichable:birch_cutting_board",
+    "sandwichable:jungle_cutting_board",
+    "sandwichable:acacia_cutting_board",
+    "sandwichable:dark_oak_cutting_board",
+    "sandwichable:crimson_cutting_board",
+    "sandwichable:warped_cutting_board"
+  ]
+}


### PR DESCRIPTION
This PR fixes the `Place down the cutting board` quest located in the Chef Boyardee section. 
The reason the quest wasn't working before is that it was looking for the `sandwichable:cutting_boards` tag on the blocks for the observation to trigger, but no such block tag existed, only an item tag by the same name that was applied to all the cutting boards.