### PR TITLE
add: log AQM2 version using kubejs reading from bcc.json

### DIFF
--- a/kubejs/startup_scripts/packversion.js
+++ b/kubejs/startup_scripts/packversion.js
@@ -1,1 +1,2 @@
-console.info('Loading Another Quality Modpack 2 KubeJS')
+const version = JsonIO.read('config/bcc.json')
+console.info(`Loading Another Quality Modpack 2 v${version.modpackVersion} KubeJS`)


### PR DESCRIPTION
No more asking "which version of the modpack are you on?" and being answered "latest"